### PR TITLE
return 1 in write()

### DIFF
--- a/Arduino & ESP8266/SC16IS752.cpp
+++ b/Arduino & ESP8266/SC16IS752.cpp
@@ -75,6 +75,7 @@ int SC16IS752::read(uint8_t channel)
 size_t SC16IS752::write(uint8_t channel, uint8_t val)
 {
 	WriteByte(channel, val);
+	return 1;
 }
 
 void SC16IS752::pinMode(uint8_t pin, uint8_t i_o)


### PR DESCRIPTION
I added return statement in write function.

Without this change, some functions that checks the return value of write function will fail.

I faced the issue when I define a class that inherits Arduino Print class,
because its default implementation of print functions checks the return value of write.
I only saw a first character on my terminal when I tried to print string.
https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Print.cpp#L38